### PR TITLE
Add "type": "module" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "GitHub Actions For Dune Query Updates",
   "version": "0.0.0",
   "author": "Ben Smith (@bh2smith)",
+  "type": "module",
   "private": false,
   "bin": {
     "dune-update": "./dist/cli.js"


### PR DESCRIPTION
## Summary
- Fixes `MODULE_TYPELESS_PACKAGE_JSON` warning at runtime
- The bundle is ESM (due to @actions/core v3), so package.json needs to declare it

## Test plan
- [ ] CI passes
- [ ] Re-tag v0.2.0 or create v0.2.1 and verify warning is gone in demo repo